### PR TITLE
Update PlayerUpdates.cpp

### DIFF
--- a/src/server/game/Entities/Player/PlayerUpdates.cpp
+++ b/src/server/game/Entities/Player/PlayerUpdates.cpp
@@ -1499,8 +1499,8 @@ void Player::UpdatePvP(bool state, bool _override)
 void Player::UpdatePotionCooldown(Spell* spell)
 {
     // no potion used i combat or still in combat
-    if (!GetLastPotionId() || IsInCombat())
-        return;
+    /*if (!GetLastPotionId() || IsInCombat())
+        return;*/
 
     // Call not from spell cast, send cooldown event for item spells if no in
     // combat


### PR DESCRIPTION
Players can now use more potions in combat, as long as they are off cooldown.